### PR TITLE
Clear error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 0.0.9 (not released)
 - Sofort support ([#5158](https://github.com/DivanteLtd/vue-storefront/issues/5158))
 - Klarna support ([#5157](https://github.com/DivanteLtd/vue-storefront/pull/5157))
+- Clearing error private refs after succesful payment & error public ref before makePayment action from payment method ([#6](https://github.com/vuestorefront/checkout-com/pull/6))
 
 ## 0.0.8
 

--- a/__tests__/useCko.spec.ts
+++ b/__tests__/useCko.spec.ts
@@ -337,6 +337,27 @@ describe('[checkout-com] useCko', () => {
     expect(response).toBe(finalizeTransactionResponse);
   });
 
+  it('clears error and makes payment for credit card', async () => {
+    error.value = 'mockedValue';
+
+    /*eslint-disable */
+    const payload = {
+      cartId: '1',
+      email: 'a@gmail.com',
+      contextDataId: '12',
+      secure3d: true,
+      success_url: null,
+      failure_url: null
+    }
+
+    localStorageMock.getItem.mockImplementation(() => 'true')
+    /* eslint-enable */
+
+    await makePayment(payload);
+
+    expect(error.value).toBe(null);
+  });
+
   it('makes payment for saved card', async () => {
     selectedPaymentMethod.value = CkoPaymentType.SAVED_CARD;
     /*eslint-disable */

--- a/__tests__/useCkoCard.spec.ts
+++ b/__tests__/useCkoCard.spec.ts
@@ -178,6 +178,30 @@ describe('[checkout-com] useCkoCard', () => {
 
     });
 
+    it('calls createPayment & returns proper success response & clears error if any from previous try', async () => {
+
+      (getTransactionToken as jest.Mock).mockImplementation(() => 'abc');
+      /*eslint-disable */
+      const payload = {
+        cartId: 15,
+        contextDataId: 'abc',
+        email: 'ab@gmail.com',
+        secure3d: true,
+        savePaymentInstrument: true,
+        success_url: null,
+        failure_url: null
+      };
+      /* eslint-enable */
+
+      error.value = 'mockd';
+      const response = await makePayment(payload);
+
+      expect(createPayment).toHaveBeenCalled();
+      expect(response).toEqual(defaultPaymentResponse);
+      expect(error.value).toBe(null);
+
+    });
+
     it('uses default values for success and failure url and save_payment_instrument', async () => {
       const token = 'abc';
       (getTransactionToken as jest.Mock).mockImplementation(() => token);

--- a/__tests__/useCkoKlarna.spec.ts
+++ b/__tests__/useCkoKlarna.spec.ts
@@ -95,6 +95,30 @@ describe('[checkout-com] useCkoKlarna', () => {
 
     });
 
+    it('calls createPayment & returns proper success response & clears error if any from previous try', async () => {
+
+      (getTransactionToken as jest.Mock).mockImplementation(() => 'abc');
+      /*eslint-disable */
+      const payload = {
+        cartId: 15,
+        contextDataId: 'abc',
+        email: 'ab@gmail.com',
+        secure3d: true,
+        savePaymentInstrument: true,
+        success_url: null,
+        failure_url: null
+      };
+      /* eslint-enable */
+
+      error.value = 'mockd';
+      const response = await makePayment(payload);
+
+      expect(createPayment).toHaveBeenCalled();
+      expect(response).toEqual(defaultPaymentResponse);
+      expect(error.value).toBe(null);
+
+    });
+
     it('uses default values for success and failure url and save_payment_instrument', async () => {
       const token = 'abc';
       (getTransactionToken as jest.Mock).mockImplementation(() => token);

--- a/__tests__/useCkoPaypal.spec.ts
+++ b/__tests__/useCkoPaypal.spec.ts
@@ -100,6 +100,29 @@ describe('[checkout-com] useCkoPaypal', () => {
 
   });
 
+  it('calls createPayment & returns proper success response & clears error if any from previous try', async () => {
+
+    /*eslint-disable */
+    const payload = {
+      cartId: 15,
+      contextDataId: 'abc',
+      email: 'ab@gmail.com',
+      secure3d: true,
+      savePaymentInstrument: true,
+      success_url: null,
+      failure_url: null
+    };
+    /* eslint-enable */
+
+    error.value = 'mockd';
+    const response = await makePayment(payload);
+
+    expect(createPayment).toHaveBeenCalled();
+    expect(response).toEqual(defaultPaymentResponse);
+    expect(error.value).toBe(null);
+
+  });
+
   it('uses default values for success and failure url and save_payment_instrument and reference', async () => {
 
     /*eslint-disable */

--- a/__tests__/useCkoSofort.spec.ts
+++ b/__tests__/useCkoSofort.spec.ts
@@ -94,6 +94,27 @@ describe('[checkout-com] useCkoSofort', () => {
 
   });
 
+  it('calls createPayment & returns proper success response & clears error if any from previous try', async () => {
+
+    /*eslint-disable */
+    const payload = {
+      cartId: 15,
+      contextDataId: 'abc',
+      email: 'ab@gmail.com',
+      success_url: null,
+      failure_url: null
+    };
+    /* eslint-enable */
+
+    error.value = 'mockd';
+    const response = await makePayment(payload);
+
+    expect(createPayment).toHaveBeenCalled();
+    expect(response).toEqual(defaultPaymentResponse);
+    expect(error.value).toBe(null);
+
+  });
+
   it('uses default values for success and failure url and reference', async () => {
 
     /*eslint-disable */

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vue-storefront/checkout-com",
-  "version": "0.0.8-lc.10",
+  "version": "0.0.8-lc.11",
   "sideEffects": false,
   "private": true,
   "main": "lib/index.cjs.js",
@@ -13,8 +13,8 @@
     "prepublish": "yarn build"
   },
   "dependencies": {
-    "@vue-storefront/core": "2.0.12-lc.10",
-    "@vue/composition-api": "1.0.0-beta.19",
+    "@vue-storefront/core": "2.0.12-lc.16",
+    "@vue/composition-api": "1.0.0-beta.20",
     "axios": "^0.19.2",
     "express": "^4.17.1",
     "vue": "^2.6.x"

--- a/src/useCko.ts
+++ b/src/useCko.ts
@@ -3,7 +3,7 @@
 import { createContext } from './payment';
 import { getSaveInstrumentKey, CardConfiguration, KlarnaConfiguration } from './configuration';
 import { sharedRef } from '@vue-storefront/core';
-import { computed } from '@vue/composition-api';
+import { computed, Ref } from '@vue/composition-api';
 import { CkoPaymentType } from './helpers';
 import useCkoCard from './useCkoCard';
 import useCkoPaypal from './useCkoPaypal';
@@ -34,7 +34,7 @@ const useCko = () => {
   const availableMethods = sharedRef([], 'useCko-availableMethods');
   const contextId = sharedRef<string>(null, 'useCko-contextId');
   const requiresCvv = sharedRef(false, 'useCko-requiresCvv');
-  const selectedPaymentMethod = sharedRef(CkoPaymentType.NOT_SELECTED, 'useCko-selectedPaymentMethod');
+  const selectedPaymentMethod = sharedRef<CkoPaymentType>(CkoPaymentType.NOT_SELECTED, 'useCko-selectedPaymentMethod');
 
   const {
     initCardForm,
@@ -47,7 +47,7 @@ const useCko = () => {
     removeTransactionToken,
     storedPaymentInstruments,
     submitDisabled
-  } = useCkoCard(selectedPaymentMethod);
+  } = useCkoCard(selectedPaymentMethod as any);
 
   const {
     initKlarnaForm,
@@ -144,6 +144,8 @@ const useCko = () => {
       error.value = new Error('Not supported payment method');
       return;
     }
+
+    error.value = null;
 
     const response = await finalizeTransactionFunction({
       cartId,

--- a/src/useCkoCard.ts
+++ b/src/useCkoCard.ts
@@ -60,6 +60,7 @@ const useCkoCard = (selectedPaymentMethod: Ref<CkoPaymentType>) => {
         throw new Error(payment.data.error_type);
       }
 
+      error.value = null;
       return payment;
     } catch (e) {
       removeTransactionToken();

--- a/src/useCkoKlarna.ts
+++ b/src/useCkoKlarna.ts
@@ -41,7 +41,8 @@ const useCkoKlarna = () => {
       if (![200, 202].includes(payment.status)) {
         throw new Error(payment.data.error_type);
       }
-
+      
+      error.value = null;
       return payment;
     } catch (e) {
       removeTransactionToken();

--- a/src/useCkoPaypal.ts
+++ b/src/useCkoPaypal.ts
@@ -38,6 +38,7 @@ const useCkoPaypal = () => {
         throw new Error(payment.data.error_type);
       }
 
+      error.value = null;
       return payment;
     } catch (e) {
       error.value = e;

--- a/src/useCkoSofort.ts
+++ b/src/useCkoSofort.ts
@@ -34,6 +34,7 @@ const useCkoSofort = () => {
         throw new Error(payment.data.error_type);
       }
 
+      error.value = null;
       return payment;
     } catch (e) {
       error.value = e;


### PR DESCRIPTION
The problem is if we are trying second+ time to pay - old error won't disappear. This PR clears public `error` ref from useCko & private `error` refs from useCkoX. Also written unit tests for that