### PR TITLE
Add products param to createContext

### DIFF
--- a/src/payment.ts
+++ b/src/payment.ts
@@ -10,11 +10,13 @@ const createOptions = () => ({
   }
 });
 
-export const createContext = async ({ reference, email = null }) =>
+export const createContext = async ({ reference, email = null, products = null }) => 
   axios.post(`${getApiUrl()}/api/contexts`, {
     reference,
-    ...(email ? { customer_email: email } : {})
+    ...(email ? { customer_email: email } : {}),
+    ...(products ? { products: products } : {})
   }, createOptions());
+  
 
 export const createPayment = async (payload: PaymentMethodPayload) =>
   axios.post(

--- a/src/useCko.ts
+++ b/src/useCko.ts
@@ -66,9 +66,9 @@ const useCko = () => {
     error: sofortError
   } = useCkoSofort();
 
-  const loadAvailableMethods = async (reference, email?) => {
+  const loadAvailableMethods = async (reference, email?, products?) => {
     try {
-      const response = await createContext({ reference, email });
+      const response = await createContext({ reference, email, products });
       availableMethods.value = [
         ...response.data.apms,
         { name: 'card' }


### PR DESCRIPTION
On create of session we need to extend order_lines items for Klarna integration.
To do that we need to pass products to createContext method. 
Tested. 

[Klarna docs, create a session](https://docs.checkout.com/payments/payment-methods/invoice-and-pay-later/klarna)