### PR TITLE
useCko export error update tests

### DIFF
--- a/__tests__/useCko.spec.ts
+++ b/__tests__/useCko.spec.ts
@@ -203,11 +203,11 @@ describe('[checkout-com] useCko', () => {
 
   it('sets error if available methods fails', async () => {
 
-    const errorMessage = 'abc';
+    const errorMessage = 'load available methods fails';
     const payload = {
       reference: '1'
     };
-    (createContext as jest.Mock).mockImplementation(() => {
+    const mockCreateContext = (createContext as jest.Mock).mockImplementation(() => {
       throw new Error(errorMessage);
     });
 
@@ -215,6 +215,7 @@ describe('[checkout-com] useCko', () => {
 
     expect(error.value.message).toEqual(errorMessage);
 
+    mockCreateContext.mockReset();
   });
 
   it('stops initForm if initMethods is an empty object', () => {
@@ -339,7 +340,8 @@ describe('[checkout-com] useCko', () => {
   });
 
   it('clears error and makes payment for credit card', async () => {
-    error.value = 'mockedValue';
+    await makePayment({});
+    expect(error.value.message).toBe('Payment method not selected');
 
     /*eslint-disable */
     const payload = {

--- a/__tests__/useCko.spec.ts
+++ b/__tests__/useCko.spec.ts
@@ -1,6 +1,7 @@
 import useCko from '../src/useCko';
 import { createContext } from '../src/payment';
 import { CkoPaymentType } from '../src/helpers';
+import { ref } from '@vue/composition-api';
 
 const contextPaymentMethods = [
   {
@@ -61,7 +62,7 @@ const useCkoKlarnaMock = {
 const useCkoCardMock = {
   initCardForm: jest.fn(),
   makePayment: jest.fn(() => finalizeTransactionResponse),
-  error: jest.fn(),
+  error: ref(null),
   submitForm: jest.fn(),
   setPaymentInstrument: jest.fn(),
   removePaymentInstrument: jest.fn(),
@@ -88,7 +89,7 @@ jest.mock('../src/payment', () => ({
 }));
 
 jest.mock('@vue-storefront/core', () => ({
-  sharedRef: value => ({value})
+  sharedRef: value => ref(value)
 }))
 
 const localStorageMock = {
@@ -340,10 +341,12 @@ describe('[checkout-com] useCko', () => {
   });
 
   it('clears error and makes payment for credit card', async () => {
+    selectedPaymentMethod.value = null;
     await makePayment({});
     expect(error.value.message).toBe('Payment method not selected');
 
     /*eslint-disable */
+    selectedPaymentMethod.value = CkoPaymentType.CREDIT_CARD;
     const payload = {
       cartId: '1',
       email: 'a@gmail.com',
@@ -353,7 +356,7 @@ describe('[checkout-com] useCko', () => {
       failure_url: null
     }
 
-    localStorageMock.getItem.mockImplementation(() => 'true')
+    localStorageMock.getItem.mockImplementation(() => 'true');
     /* eslint-enable */
 
     await makePayment(payload);

--- a/src/useCko.ts
+++ b/src/useCko.ts
@@ -170,7 +170,7 @@ const useCko = () => {
 
   return {
     availableMethods,
-    error: computed(() => error.value || cardError.value),
+    error: computed(() => error.value || cardError.value || null),
     selectedPaymentMethod,
     storedPaymentInstruments,
     submitDisabled,


### PR DESCRIPTION
Hi!  @Fifciu  I've tried to update tests after the fix for the issue https://github.com/vuestorefront/checkout-com/issues/25 
but can't understand why some of tests fail.
here is the tests result
```bash
● [checkout-com] useCko › does not make payment if payment method not selected

    expect(received).toBe(expected) // Object.is equality

    Expected: "Payment method not selected"
    Received: "load available methods fails"

      296 |     await makePayment({});
      297 |
    > 298 |     expect(error.value.message).toBe('Payment method not selected');
          |                                 ^
      299 |   });
      300 |
      301 |   it('does not make payment if payment method not selected without params', async () => {

      at __tests__/useCko.spec.ts:298:33
      at step (node_modules/tslib/tslib.js:144:27)
      at Object.next (node_modules/tslib/tslib.js:125:57)
      at fulfilled (node_modules/tslib/tslib.js:115:62)

  ● [checkout-com] useCko › does not make payment if payment method not selected without params

    expect(received).toBe(expected) // Object.is equality

    Expected: "Payment method not selected"
    Received: "load available methods fails"

      302 |     await makePayment();
      303 |
    > 304 |     expect(error.value.message).toBe('Payment method not selected');
          |                                 ^
      305 |   });
      306 |
      307 |   it('makes payment for credit card', async () => {

      at __tests__/useCko.spec.ts:304:33
      at step (node_modules/tslib/tslib.js:144:27)
      at Object.next (node_modules/tslib/tslib.js:125:57)
      at fulfilled (node_modules/tslib/tslib.js:115:62)

  ● [checkout-com] useCko › clears error and makes payment for credit card

    expect(received).toBe(expected) // Object.is equality

    Expected: "Payment method not selected"
    Received: "load available methods fails"

      342 |   it('clears error and makes payment for credit card', async () => {
      343 |     await makePayment({});
    > 344 |     expect(error.value.message).toBe('Payment method not selected');
          |                                 ^
      345 |
      346 |     /*eslint-disable */
      347 |     const payload = {

      at __tests__/useCko.spec.ts:344:33
      at step (node_modules/tslib/tslib.js:144:27)
      at Object.next (node_modules/tslib/tslib.js:125:57)
      at fulfilled (node_modules/tslib/tslib.js:115:62)

  ● [checkout-com] useCko › throws with saved card when CVV required and not provided

    expect(received).toBe(expected) // Object.is equality

    Expected: "CVV is required"
    Received: "load available methods fails"

      415 |
      416 |     await makePayment(payload);
    > 417 |     expect(error.value.message).toBe('CVV is required');
          |                                 ^
      418 |   });
      419 |
      420 |   it('makes payment for PayPal', async () => {

      at __tests__/useCko.spec.ts:417:33
      at step (node_modules/tslib/tslib.js:144:27)
      at Object.next (node_modules/tslib/tslib.js:125:57)
      at fulfilled (node_modules/tslib/tslib.js:115:62)

  ● [checkout-com] useCko › sets error for not supported payment method

    expect(received).toBe(expected) // Object.is equality

    Expected: "Not supported payment method"
    Received: "load available methods fails"

      526 |
      527 |     expect(useCkoPaypalMock.makePayment).not.toHaveBeenCalled();
    > 528 |     expect(error.value.message).toBe('Not supported payment method');
          |                                 ^
      529 |   });
      530 |
      531 |   it('inherits error from payment methods makePayment', async () => {

      at __tests__/useCko.spec.ts:528:33
      at step (node_modules/tslib/tslib.js:144:27)
      at Object.next (node_modules/tslib/tslib.js:125:57)
      at fulfilled (node_modules/tslib/tslib.js:115:62)

  ● [checkout-com] useCko › inherits error from payment methods makePayment

    expect(received).toBe(expected) // Object.is equality

    Expected: "some-paypal-weird-error"
    Received: "load available methods fails"

      533 |
      534 |     await makePayment({});
    > 535 |     expect(error.value.message).toBe(useCkoPaypalMock.error.value.message);
          |                                 ^
      536 |   });
      537 |
      538 |   it('sets savePaymentInstrument', () => {

      at __tests__/useCko.spec.ts:535:33
      at step (node_modules/tslib/tslib.js:144:27)
      at Object.next (node_modules/tslib/tslib.js:125:57)
      at fulfilled (node_modules/tslib/tslib.js:115:62)

------------------|----------|----------|----------|----------|-------------------|
File              |  % Stmts | % Branch |  % Funcs |  % Lines | Uncovered Line #s |
------------------|----------|----------|----------|----------|-------------------|
All files         |      100 |    97.55 |    98.67 |      100 |                   |
 configuration.ts |      100 |      100 |      100 |      100 |                   |
 helpers.ts       |      100 |    95.45 |      100 |      100 |                65 |
 index.ts         |      100 |      100 |    85.71 |      100 |                   |
 payment.ts       |      100 |       75 |      100 |      100 |             13,17 |
 useCko.ts        |      100 |    95.45 |      100 |      100 |           115,173 |
 useCkoCard.ts    |      100 |      100 |      100 |      100 |                   |
 useCkoKlarna.ts  |      100 |      100 |      100 |      100 |                   |
 useCkoPaypal.ts  |      100 |      100 |      100 |      100 |                   |
 useCkoSofort.ts  |      100 |      100 |      100 |      100 |                   |
------------------|----------|----------|----------|----------|-------------------|
Test Suites: 1 failed, 8 passed, 9 total
Tests:       6 failed, 90 passed, 96 total
```

it looks like `computed` property that is exported in `useCko.ts` https://github.com/vuestorefront/checkout-com/blob/066b1c647b8e969b0ee16de845d3e931a0edd5e7/src/useCko.ts#L173  for some reason doesn't react on updating `error` variable https://github.com/vuestorefront/checkout-com/blob/066b1c647b8e969b0ee16de845d3e931a0edd5e7/src/useCko.ts#L33
and always returns only the first value that is set to `error`

Do you have any idea how to fix it?